### PR TITLE
Initialize monorepo skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install black isort pytest
+      - run: black --check .
+      - run: isort --check-only .
+      - run: pytest
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npx eslint src
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+JobXpert is a monorepo with a FastAPI backend and a Vite powered React frontend. The backend exposes a health check on port 8000 while the frontend shows a circle that turns green when the check succeeds or red on failure. Tailwind CSS and Framer Motion provide a dark themed interface and Docker Compose runs both services on ports 8000 and 5173.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health():
+    return {"ok": True}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  backend:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: sh -c "pip install -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port 8000"
+    ports:
+      - '8000:8000'
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: sh -c "npm install && npm run dev -- --host"
+    ports:
+      - '5173:5173'
+    environment:
+      - PORT=5173

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.16.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import './index.css'
+
+function App() {
+  const [ok, setOk] = useState(null)
+  useEffect(() => {
+    fetch('/health').then(r => setOk(r.ok)).catch(() => setOk(false))
+  }, [])
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-900">
+      <motion.div
+        className={`rounded-full w-16 h-16 ${ok === null ? 'bg-gray-700' : ok ? 'bg-green-500' : 'bg-red-500'}`}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      />
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html { color-scheme: dark; }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
## Summary
- add FastAPI backend with /health route
- add React frontend using Vite, Tailwind and Framer Motion
- wire up docker-compose services for frontend and backend
- set up CI with black, isort, pytest, eslint and build steps

## Testing
- `black backend frontend`
- `isort --check-only backend`
- `pytest`
- `npm install` *(fails: 403 Forbidden)*
- `npx eslint src` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa5df368c8328ba13062f1438e449