### PR TITLE
Add auth system and protected frontend routes

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,20 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,57 @@
-from fastapi import FastAPI
+import os
+from datetime import datetime, timedelta
+from fastapi import Depends, FastAPI, HTTPException, status
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+import jwt
+from passlib.context import CryptContext
+from .db import Base, engine, get_db
+from .models import User
+
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
+pwd_context = CryptContext(schemes=["bcrypt"])
+JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+
+class UserIn(BaseModel):
+    email: EmailStr
+    password: str
+
+class Token(BaseModel):
+    access_token: str
 
 @app.get("/health")
 async def health():
     return {"ok": True}
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+def verify_password(password: str, hashed: str) -> bool:
+    return pwd_context.verify(password, hashed)
+
+def create_token(user_id: int) -> str:
+    payload = {"sub": str(user_id), "exp": datetime.utcnow() + timedelta(minutes=60)}
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+@app.post("/auth/signup", response_model=Token)
+def signup(data: UserIn, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.email == data.email).first():
+        raise HTTPException(status_code=400, detail="Email taken")
+    user = User(email=data.email, password_hash=hash_password(data.password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    token = create_token(user.id)
+    return {"access_token": token}
+
+@app.post("/auth/login", response_model=Token)
+def login(data: UserIn, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == data.email).first()
+    if not user or not verify_password(data.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid credentials")
+    token = create_token(user.id)
+    return {"access_token": token}
+

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+from .user import User

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from enum import Enum
+from sqlalchemy import Column, Integer, String, DateTime, Enum as SQLEnum, Boolean
+from . import Base
+
+class RoleEnum(Enum):
+    user = "user"
+    admin = "admin"
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    role = Column(SQLEnum(RoleEnum), default=RoleEnum.user, nullable=False)
+    is_active = Column(Boolean, default=True)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,6 @@
 fastapi
 uvicorn[standard]
+SQLAlchemy
+alembic
+passlib[bcrypt]
+PyJWT

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "framer-motion": "^10.16.4"
+    "framer-motion": "^10.16.4",
+    "react-router-dom": "^6.21.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import './index.css'
+import Login from './pages/Login'
+import Signup from './pages/Signup'
+import ProtectedRoute from './ProtectedRoute'
 
-function App() {
+const Home = () => {
   const [ok, setOk] = useState(null)
   useEffect(() => {
     fetch('/health').then(r => setOk(r.ok)).catch(() => setOk(false))
   }, [])
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-900">
+    <div className='flex items-center justify-center min-h-screen bg-gray-900'>
       <motion.div
         className={`rounded-full w-16 h-16 ${ok === null ? 'bg-gray-700' : ok ? 'bg-green-500' : 'bg-red-500'}`}
         initial={{ opacity: 0 }}
@@ -18,4 +22,17 @@ function App() {
   )
 }
 
+function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path='/login' element={<Login />} />
+        <Route path='/signup' element={<Signup />} />
+        <Route path='/' element={<ProtectedRoute><Home /></ProtectedRoute>} />
+      </Routes>
+    </Router>
+  )
+}
+
 export default App
+

--- a/frontend/src/ProtectedRoute.jsx
+++ b/frontend/src/ProtectedRoute.jsx
@@ -1,0 +1,7 @@
+import { Navigate } from 'react-router-dom'
+const ProtectedRoute = ({ children }) => {
+  const token = localStorage.getItem('jx_token')
+  if (!token) return <Navigate to='/login' replace />
+  return children
+}
+export default ProtectedRoute

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { Link, useNavigate } from 'react-router-dom'
+
+const Login = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const navigate = useNavigate()
+
+  const submit = async e => {
+    e.preventDefault()
+    const res = await fetch('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      const data = await res.json()
+      localStorage.setItem('jx_token', data.access_token)
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className='flex items-center justify-center min-h-screen bg-gray-900'>
+      <motion.form
+        onSubmit={submit}
+        initial={{ y: 50, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        className='bg-gray-800 p-8 rounded w-full max-w-md flex flex-col gap-4'
+      >
+        <div className='flex flex-col md:flex-row gap-4'>
+          <input
+            className='p-2 rounded bg-gray-700 text-white flex-1'
+            placeholder='Email'
+            type='email'
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <input
+            className='p-2 rounded bg-gray-700 text-white flex-1'
+            placeholder='Password'
+            type='password'
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        <button className='bg-blue-600 py-2 rounded'>Login</button>
+        <Link to='/signup' className='text-sm text-center text-blue-400'>Sign up</Link>
+      </motion.form>
+    </div>
+  )
+}
+
+export default Login
+

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { Link, useNavigate } from 'react-router-dom'
+
+const Signup = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const navigate = useNavigate()
+
+  const submit = async e => {
+    e.preventDefault()
+    const res = await fetch('/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      const data = await res.json()
+      localStorage.setItem('jx_token', data.access_token)
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className='flex items-center justify-center min-h-screen bg-gray-900'>
+      <motion.form
+        onSubmit={submit}
+        initial={{ y: 50, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        className='bg-gray-800 p-8 rounded w-full max-w-md flex flex-col gap-4'
+      >
+        <div className='flex flex-col md:flex-row gap-4'>
+          <input
+            className='p-2 rounded bg-gray-700 text-white flex-1'
+            placeholder='Email'
+            type='email'
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <input
+            className='p-2 rounded bg-gray-700 text-white flex-1'
+            placeholder='Password'
+            type='password'
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        <button className='bg-blue-600 py-2 rounded'>Sign Up</button>
+        <Link to='/login' className='text-sm text-center text-blue-400'>Login</Link>
+      </motion.form>
+    </div>
+  )
+}
+
+export default Signup
+


### PR DESCRIPTION
## Summary
- integrate SQLAlchemy database and user model
- create signup and login routes with JWT auth
- implement session factory
- add login and signup pages with slide-up forms
- add ProtectedRoute HOC and router setup

## Testing
- `python -m py_compile $(git ls-files "backend/*.py" "backend/models/*.py")`
- `pip install -q -r backend/requirements.txt`
- `npm install` *(passes)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_686aa8fa154483289b7c12cc8fc0aac2