### PR TITLE
Add resume uploads

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,1 +1,3 @@
 from .user import User
+
+from .resume import Resume

--- a/backend/models/resume.py
+++ b/backend/models/resume.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, UniqueConstraint
+from ..db import Base
+class Resume(Base):
+    __tablename__ = "resumes"
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    path = Column(String(255), nullable=False)
+    uploaded_at = Column(DateTime, default=datetime.utcnow)
+    __table_args__ = (UniqueConstraint('user_id', 'path'),)
+

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from sqlalchemy import Column, Integer, String, DateTime, Enum as SQLEnum, Boolean
-from . import Base
-
+from ..db import Base
 class RoleEnum(Enum):
     user = "user"
     admin = "admin"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "framer-motion": "^10.16.4",
-    "react-router-dom": "^6.21.0"
+    "react-router-dom": "^6.21.0",
+    "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,26 +1,9 @@
-import { useEffect, useState } from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-import { motion } from 'framer-motion'
 import './index.css'
 import Login from './pages/Login'
 import Signup from './pages/Signup'
+import Dashboard from './pages/Dashboard'
 import ProtectedRoute from './ProtectedRoute'
-
-const Home = () => {
-  const [ok, setOk] = useState(null)
-  useEffect(() => {
-    fetch('/health').then(r => setOk(r.ok)).catch(() => setOk(false))
-  }, [])
-  return (
-    <div className='flex items-center justify-center min-h-screen bg-gray-900'>
-      <motion.div
-        className={`rounded-full w-16 h-16 ${ok === null ? 'bg-gray-700' : ok ? 'bg-green-500' : 'bg-red-500'}`}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-      />
-    </div>
-  )
-}
 
 function App() {
   return (
@@ -28,11 +11,10 @@ function App() {
       <Routes>
         <Route path='/login' element={<Login />} />
         <Route path='/signup' element={<Signup />} />
-        <Route path='/' element={<ProtectedRoute><Home /></ProtectedRoute>} />
+        <Route path='/' element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
       </Routes>
     </Router>
   )
 }
 
 export default App
-

--- a/frontend/src/components/UploadResume.jsx
+++ b/frontend/src/components/UploadResume.jsx
@@ -1,0 +1,28 @@
+import { useDropzone } from 'react-dropzone'
+
+const UploadResume = ({ onUploaded }) => {
+  const token = localStorage.getItem('jx_token')
+  const onDrop = async files => {
+    const file = files[0]
+    if (!file) return
+    const data = new FormData()
+    data.append('file', file)
+    const res = await fetch('/resumes/upload', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: data
+    })
+    if (res.ok) {
+      const row = await res.json()
+      onUploaded(row)
+    }
+  }
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop })
+  return (
+    <div {...getRootProps()} className={`border-2 border-dashed p-8 rounded text-center cursor-pointer ${isDragActive ? 'bg-gray-700' : 'bg-gray-800'}`}>\n      <input {...getInputProps()} />
+      <p>Drop resume here</p>
+    </div>
+  )
+}
+
+export default UploadResume

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import UploadResume from '../components/UploadResume'
+
+const Dashboard = () => {
+  const [resumes, setResumes] = useState([])
+  const token = localStorage.getItem('jx_token')
+
+  const fetchResumes = async () => {
+    const res = await fetch('/resumes', { headers: { Authorization: `Bearer ${token}` } })
+    if (res.ok) setResumes(await res.json())
+  }
+
+  useEffect(() => { fetchResumes() }, [])
+
+  const addResume = r => setResumes(prev => [r, ...prev])
+
+  return (
+    <div className='min-h-screen bg-gray-900 p-8 flex flex-col gap-8'>
+      <UploadResume onUploaded={addResume} />
+      <div className='grid md:grid-cols-3 gap-4'>
+        {resumes.map(r => (
+          <motion.div key={r.id} whileHover={{ scale: 1.05 }} className='bg-gray-800 p-4 rounded'>
+            <p className='break-all'>{r.path}</p>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Dashboard


### PR DESCRIPTION
## Summary
- model resumes table and create upload directory
- implement resume upload API and listing
- support uploading resumes in frontend dashboard
- integrate drag-and-drop upload zone
- add react-dropzone dependency

## Testing
- `python -m py_compile backend/main.py backend/models/resume.py backend/models/user.py`
- `pip install email-validator`
- `pip install python-multipart`
- `uvicorn backend.main:app --port 8000` *(fails without python-multipart, then succeeds)*
- `npm install --silent`
- `npm run build --silent` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_686aaa883db8832891c0a4908345ecc5